### PR TITLE
fix: give some time to ensure the dev database is running

### DIFF
--- a/docker/wordpress-cli/install-wp-tests.sh
+++ b/docker/wordpress-cli/install-wp-tests.sh
@@ -145,6 +145,14 @@ install_db() {
 		fi
 	fi
 
+	# Await to the database to be ready, try 30 times with 1 seconds interval
+	for i in {1..30}; do
+		if mysqladmin ping --user="$DB_USER" --password="$DB_PASS"$EXTRA; then
+			break
+		fi
+		sleep 1
+	done
+
 	# create database
 	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
 	then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luc-cpl/wp-setup",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "The WordPress environment setup tool.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
This pull request adds time to ensure the database instance is up and running before create the database.